### PR TITLE
Add license to README

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,8 @@ Linux Framebuffer Benchmark
 The fbmark package contains benchmarks that aim to test and measure the
 performance of the frame buffer device (/dev/fb0).
 
+It is licensed under the GNU General Public License v3.0 or later.
+
 Have fun,
 
 Nicolas Caramelli


### PR DESCRIPTION
Fixes #2 

Found license in source code https://github.com/caramelli/fbmark/blob/c6eddced28efd544db10cad1d87e760ad830cdc0/fb_mandelbrot.c#L7-L8

Usins SPDX Full name: https://spdx.org/licenses/GPL-3.0-or-later.html