### PR TITLE
Sierpinski test: prevent segmentation fault

### DIFF
--- a/fb_sierpinski.c
+++ b/fb_sierpinski.c
@@ -27,6 +27,8 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
 typedef struct {
   int x;
   int y;
@@ -59,7 +61,7 @@ int main(int argc, char **argv)
   buffer = mmap(NULL, len, PROT_WRITE, MAP_SHARED, fd, 0);
   data = malloc(width * height * info.bits_per_pixel / 8);
   angle = 0;
-  r = height / 2 - 8;
+  r = MIN(height, width) / 2 - 8;
   iters = 1024;
   frames = time = 0;
   gettimeofday(&last, NULL);


### PR DESCRIPTION
When height > width, the radius may exceed the width, leading to negative indexes while accessing the data buffer, originating a segmentation fault.
Prevent this condition by choosing always the lower dimension.

Signed-off-by: Pierluigi Passaro <pierluigi.p@variscite.com>